### PR TITLE
Hacking some Python2 requirement versions

### DIFF
--- a/Dockerfile_test_build
+++ b/Dockerfile_test_build
@@ -25,7 +25,7 @@ WORKDIR /workspace
 COPY requirements.txt /workspace/requirements.txt
 COPY README.md /workspace/README.md
 
-RUN pip install --upgrade pip setuptools
+RUN pip install --upgrade 'setuptools<45.0.0'
 RUN pip install -r requirements.txt
 
 COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+setuptools<45.0.0
+more-itertools<=5.0.0
+attrs==19.1.0
 pytest==4.6.5
 mock==2.0.0
 PyHamcrest==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ future==0.16.0  # needed by gosnmp_python, gossh_python and goodbc_python
 snmpsim==0.4.7
 futures==3.3.0
 guppy==0.1.11
+zipp==2.2.1


### PR DESCRIPTION
This PR addresses the dwindling support in PyPI for Python2 by pinning a few packages to be versions that support Python2; they are:

- setuptools
- more-itertools
- attrs
